### PR TITLE
Verify card readiness before building UID

### DIFF
--- a/pysatochip/CardConnector.py
+++ b/pysatochip/CardConnector.py
@@ -140,6 +140,7 @@ class RemovalObserver(CardObserver):
                         self.cc.card_initiate_secure_channel()
 
                     if status_ready:
+                        last_exc = None
                         for _ in range(3):
                             try:
                                 (response_CPLC, sw1, sw2) = self.cc.card_get_CPLC()
@@ -160,8 +161,11 @@ class RemovalObserver(CardObserver):
                                 logger.debug(f"DEBUG UID_SHA1: {self.cc.UID_SHA1}")
                                 break
                             except Exception as exc:
+                                last_exc = exc
                                 logger.warning(f"Error during CPLC/IIN/CIN: {repr(exc)}")
                                 time.sleep(0.1)
+                        else:
+                            raise last_exc if last_exc else Exception("Failed to fetch CPLC/IIN/CIN")
 
                 # todo: skip or not for reset_factory?
                 if self.cc.client is not None:

--- a/pysatochip/CardConnector.py
+++ b/pysatochip/CardConnector.py
@@ -144,15 +144,15 @@ class RemovalObserver(CardObserver):
                             try:
                                 (response_CPLC, sw1, sw2) = self.cc.card_get_CPLC()
                                 if sw1!=0x90 or sw2!=0x00:
-                                    raise SWException(hex((sw1<<8)+sw2))
+                                    raise SWException(response_CPLC, sw1, sw2)
                                 logger.debug(f"DEBUG CPLC: {bytes(response_CPLC).hex()}")
                                 (response_IIN, sw1, sw2) = self.cc.card_get_IIN()
                                 if sw1!=0x90 or sw2!=0x00:
-                                    raise SWException(hex((sw1<<8)+sw2))
+                                    raise SWException(response_IIN, sw1, sw2)
                                 logger.debug(f"DEBUG IIN: {bytes(response_IIN).hex()}")
                                 (response_CIN, sw1, sw2) = self.cc.card_get_CIN()
                                 if sw1!=0x90 or sw2!=0x00:
-                                    raise SWException(hex((sw1<<8)+sw2))
+                                    raise SWException(response_CIN, sw1, sw2)
                                 logger.debug(f"DEBUG CIN: {bytes(response_CIN).hex()}")
                                 self.cc.UID= response_CPLC+response_IIN+response_CIN
                                 logger.debug(f"DEBUG UID: {bytes(self.cc.UID).hex()}")

--- a/pysatochip/CardConnector.py
+++ b/pysatochip/CardConnector.py
@@ -17,6 +17,7 @@ from .certificate_validator import CertificateValidator
 import hashlib
 import hmac
 import base64
+import time
 import logging
 from os import urandom
 from typing import Union
@@ -114,23 +115,7 @@ class RemovalObserver(CardObserver):
             self.cc.cardservice.connection = card.createConnection()
             self.cc.cardservice.connection.connect()
             self.cc.cardservice.connection.addObserver(self.observer)
-            
-            # get CPLC
-            try:
-                (response_CPLC, sw1, sw2) = self.cc.card_get_CPLC()
-                logger.debug(f"DEBUG CPLC: {bytes(response_CPLC).hex()}")
-                (response_IIN, sw1, sw2) = self.cc.card_get_IIN()
-                logger.debug(f"DEBUG IIN: {bytes(response_IIN).hex()}")
-                (response_CIN, sw1, sw2) = self.cc.card_get_CIN()
-                logger.debug(f"DEBUG CIN: {bytes(response_CIN).hex()}")
-                self.cc.UID= response_CPLC+response_IIN+response_CIN
-                logger.debug(f"DEBUG UID: {bytes(self.cc.UID).hex()}")
-                self.cc.UID_SHA1= hashlib.sha1(bytes(self.cc.UID)).hexdigest()
-                logger.debug(f"DEBUG UID_SHA1: {self.cc.UID_SHA1}")
-            except Exception as exc:
-                logger.warning(f"Error during CPLC/IIN/CIN: {repr(exc)}")
-                
-            #select applet
+
             try:
                 (response, sw1, sw2) = self.cc.card_select()
                 if sw1!=0x90 or sw2!=0x00:
@@ -138,17 +123,49 @@ class RemovalObserver(CardObserver):
                     break
 
                 # During factory reset, we should not send other commands than reset...
+                status_ready = False
                 if self.cc.mode_factory_reset == False:
-                    (response, sw1, sw2, status)= self.cc.card_get_status()
+                    for _ in range(3):
+                        (response, sw1, sw2, status)= self.cc.card_get_status()
+                        if sw1==0x90 and sw2==0x00:
+                            status_ready = True
+                            break
+                        elif sw1==0x9C and sw2==0x04:
+                            break
+                        time.sleep(0.1)
                     if (sw1!=0x90 or sw2!=0x00) and (sw1!=0x9C or sw2!=0x04):
                         self.cc.card_disconnect()
                         break
                     if (self.cc.needs_secure_channel):
                         self.cc.card_initiate_secure_channel()
-                
+
+                    if status_ready:
+                        for _ in range(3):
+                            try:
+                                (response_CPLC, sw1, sw2) = self.cc.card_get_CPLC()
+                                if sw1!=0x90 or sw2!=0x00:
+                                    raise SWException(hex((sw1<<8)+sw2))
+                                logger.debug(f"DEBUG CPLC: {bytes(response_CPLC).hex()}")
+                                (response_IIN, sw1, sw2) = self.cc.card_get_IIN()
+                                if sw1!=0x90 or sw2!=0x00:
+                                    raise SWException(hex((sw1<<8)+sw2))
+                                logger.debug(f"DEBUG IIN: {bytes(response_IIN).hex()}")
+                                (response_CIN, sw1, sw2) = self.cc.card_get_CIN()
+                                if sw1!=0x90 or sw2!=0x00:
+                                    raise SWException(hex((sw1<<8)+sw2))
+                                logger.debug(f"DEBUG CIN: {bytes(response_CIN).hex()}")
+                                self.cc.UID= response_CPLC+response_IIN+response_CIN
+                                logger.debug(f"DEBUG UID: {bytes(self.cc.UID).hex()}")
+                                self.cc.UID_SHA1= hashlib.sha1(bytes(self.cc.UID)).hexdigest()
+                                logger.debug(f"DEBUG UID_SHA1: {self.cc.UID_SHA1}")
+                                break
+                            except Exception as exc:
+                                logger.warning(f"Error during CPLC/IIN/CIN: {repr(exc)}")
+                                time.sleep(0.1)
+
                 # todo: skip or not for reset_factory?
                 if self.cc.client is not None:
-                    self.cc.client.request('update_status',True)   
+                    self.cc.client.request('update_status',True)
                 
             except Exception as exc:
                 logger.warning(f"Error during connection: {repr(exc)}")

--- a/pysatochip/CardConnector.py
+++ b/pysatochip/CardConnector.py
@@ -140,32 +140,28 @@ class RemovalObserver(CardObserver):
                         self.cc.card_initiate_secure_channel()
 
                     if status_ready:
-                        last_exc = None
-                        for _ in range(3):
-                            try:
-                                (response_CPLC, sw1, sw2) = self.cc.card_get_CPLC()
-                                if sw1!=0x90 or sw2!=0x00:
-                                    raise SWException(response_CPLC, sw1, sw2)
-                                logger.debug(f"DEBUG CPLC: {bytes(response_CPLC).hex()}")
-                                (response_IIN, sw1, sw2) = self.cc.card_get_IIN()
-                                if sw1!=0x90 or sw2!=0x00:
-                                    raise SWException(response_IIN, sw1, sw2)
-                                logger.debug(f"DEBUG IIN: {bytes(response_IIN).hex()}")
-                                (response_CIN, sw1, sw2) = self.cc.card_get_CIN()
-                                if sw1!=0x90 or sw2!=0x00:
-                                    raise SWException(response_CIN, sw1, sw2)
-                                logger.debug(f"DEBUG CIN: {bytes(response_CIN).hex()}")
-                                self.cc.UID= response_CPLC+response_IIN+response_CIN
-                                logger.debug(f"DEBUG UID: {bytes(self.cc.UID).hex()}")
-                                self.cc.UID_SHA1= hashlib.sha1(bytes(self.cc.UID)).hexdigest()
-                                logger.debug(f"DEBUG UID_SHA1: {self.cc.UID_SHA1}")
-                                break
-                            except Exception as exc:
-                                last_exc = exc
-                                logger.warning(f"Error during CPLC/IIN/CIN: {repr(exc)}")
-                                time.sleep(0.1)
-                        else:
-                            raise last_exc if last_exc else Exception("Failed to fetch CPLC/IIN/CIN")
+                        def fetch_with_retry(cmd, name):
+                            last_exc = None
+                            for _ in range(3):
+                                try:
+                                    response, sw1, sw2 = cmd()
+                                    if sw1 == 0x90 and sw2 == 0x00:
+                                        logger.debug(f"DEBUG {name}: {bytes(response).hex()}")
+                                        return response
+                                    raise SWException(response, sw1, sw2)
+                                except Exception as exc:
+                                    last_exc = exc
+                                    logger.warning(f"Error fetching {name}: {repr(exc)}")
+                                    time.sleep(0.1)
+                            raise last_exc if last_exc else Exception(f"Failed to fetch {name}")
+
+                        response_CPLC = fetch_with_retry(self.cc.card_get_CPLC, "CPLC")
+                        response_IIN = fetch_with_retry(self.cc.card_get_IIN, "IIN")
+                        response_CIN = fetch_with_retry(self.cc.card_get_CIN, "CIN")
+                        self.cc.UID = response_CPLC + response_IIN + response_CIN
+                        logger.debug(f"DEBUG UID: {bytes(self.cc.UID).hex()}")
+                        self.cc.UID_SHA1 = hashlib.sha1(bytes(self.cc.UID)).hexdigest()
+                        logger.debug(f"DEBUG UID_SHA1: {self.cc.UID_SHA1}")
 
                 # todo: skip or not for reset_factory?
                 if self.cc.client is not None:
@@ -173,9 +169,10 @@ class RemovalObserver(CardObserver):
                 
             except Exception as exc:
                 logger.warning(f"Error during connection: {repr(exc)}")
+                self.cc.card_disconnect()
                 if self.cc.client is not None:
                     msg=(f"Exception while selecting card! \nOnly {self.cc.card_filter} cards are supported")
-                    self.cc.client.request('show_error',msg)   
+                    self.cc.client.request('show_error',msg)
                 
         for card in removedcards:
             logger.info(f"-Removed: {toHexString(card.atr)}")


### PR DESCRIPTION
## Summary
- Fetch CPLC/IIN/CIN only after a successful card select and status check
- Retry until the card reports ready before computing UID, validating all status words

## Testing
- `pytest` *(fails: smartcard.Exceptions.CardConnectionException: Service not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a146c9fdec8322a39556d75257d8fa