### PR TITLE
Use pycryptodomex for Seedkeeper secret decryption

### DIFF
--- a/pysatochip/SecretDecryption.py
+++ b/pysatochip/SecretDecryption.py
@@ -18,12 +18,7 @@
 from ecdsa import SigningKey, SECP256k1, ECDH
 import binascii, json, hmac, hashlib, argparse, logging
 
-import cryptography
-from cryptography import exceptions
-from cryptography.hazmat.primitives.ciphers import Cipher as CG_Cipher
-from cryptography.hazmat.primitives.ciphers import algorithms as CG_algorithms
-from cryptography.hazmat.primitives.ciphers import modes as CG_modes
-from cryptography.hazmat.backends import default_backend as CG_default_backend
+from Cryptodome.Cipher import AES
 
 from pysatochip.JCconstants import *
 
@@ -74,9 +69,8 @@ def Decrypt_Secret(privateKey, export_data):
 			raise Exception("WARNING: MAC Mismatch (Encrypted Data is invalid, tampered or corrupt)")
 
 		# Decrypt Secret
-		cipher = CG_Cipher(CG_algorithms.AES(decryption_key), CG_modes.CBC(exported_iv), backend=CG_default_backend())
-		decryptor = cipher.decryptor()
-		raw_secret = decryptor.update(exported_secret_data) + decryptor.finalize()
+		cipher = AES.new(bytes(decryption_key), AES.MODE_CBC, bytes(exported_iv))
+		raw_secret = cipher.decrypt(bytes(exported_secret_data))
 
 		try: # First just try for text based secrets like mnemonics or general password
 			decrypted_secret = raw_secret.split(b'\x00')[0][1:].decode()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pyscard>=1.9.9 #2.0.0
 ecdsa>=0.15
 pyaes>=1.6.1
-cryptography>=3.3.2
 pyopenssl>=20.0.0 # for certificate chain validation
 pycryptodomex>=3.18 # fallback when OpenSSL is unavailable
 certifi


### PR DESCRIPTION
### Motivation
- Replace `cryptography` AES-CBC primitives with `pycryptodomex` to remove the heavy `cryptography` runtime dependency and rely on the project's existing fallback crypto library. 
- Preserve the existing Seedkeeper decryption flow, key derivation and HMAC checks while simplifying the dependency surface.

### Description
- Replaced `cryptography` imports and AES-CBC usage in `pysatochip/SecretDecryption.py` with `from Cryptodome.Cipher import AES` and `AES.new(..., AES.MODE_CBC, ...)` for decryption. 
- Switched from the `cryptography` encryptor/decryptor API to `cipher.decrypt(...)` while keeping unpadding, HMAC verification and secret parsing logic unchanged. 
- Removed `cryptography>=3.3.2` from `requirements.txt` since it is no longer required by this code path.

### Testing
- Ran `python -m compileall pysatochip/SecretDecryption.py satochip_cli.py` and compilation completed successfully. 
- Ran `python -c "import pysatochip.SecretDecryption as sd; print(hasattr(sd, 'Decrypt_Secret'))"` which printed `ok True`, confirming the module and `Decrypt_Secret` are importable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a63d5d4fc83229240d39653074322)